### PR TITLE
Add AsRawFd trait for SerialPorts that support it

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 name = "slcan"
 readme = "README.md"
 repository = "https://github.com/jmaygarden/slcan.git"
-version = "0.1.3"
+version = "0.1.4"
 
 [dependencies]
 serial-core = "0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@ extern crate serial_core as serial;
 
 use serial::prelude::*;
 use std::io;
+#[cfg(target_family = "unix")]
+use std::os::unix::prelude::AsRawFd;
 
 // maximum rx buffer len: extended CAN frame with timestamp
 const SLCAN_MTU: usize = "T1111222281122334455667788EA5F\r".len() + 1;
@@ -38,6 +40,16 @@ pub struct CanSocket<P: SerialPort> {
     rbuff: [u8; SLCAN_MTU],
     rcount: usize,
     error: bool,
+}
+
+#[cfg(target_family = "unix")]
+impl<P> AsRawFd for CanSocket<P>
+where
+    P: SerialPort + AsRawFd,
+{
+    fn as_raw_fd(&self) -> std::os::unix::prelude::RawFd {
+        self.port.as_raw_fd()
+    }
 }
 
 fn hextou8(s: u8) -> Result<u8, ()> {


### PR DESCRIPTION
The *nix TTY ports implement the `AsRawFd` trait. This PR applies that trait to the thin wrapper when applicable.